### PR TITLE
Replace usage of gl_FragColor

### DIFF
--- a/resources/nor_frag.glsl
+++ b/resources/nor_frag.glsl
@@ -1,11 +1,12 @@
 #version 430 core
 
 in vec3 vNor;
+layout(location = 0) out vec4 diffuseColor;
 
 void main()
 {
 	vec3 normal = normalize(vNor);
 	// Map normal in the range [-1, 1] to color in range [0, 1];
 	vec3 color = 0.5*normal + 0.5;
-	gl_FragColor = vec4(color, 1.0);
+	diffuseColor = vec4(color, 1.0);
 }


### PR DESCRIPTION
While running this test code I encountered
`error C7616: global variable gl_FragColor is removed after version 420`

This can be fixed with a small change as described on [StackOverflow](https://stackoverflow.com/questions/51459596/using-gl-fragcolor-vs-out-vec4-color). Technically `diffuseColor` can be named anything, OpenGL simply expects a vec4 at output layout location 0.

It seems this may work on some machines due to `gl_FragColor` being reintroduced in later GLSL specifications under the compatibility profile.